### PR TITLE
use GITHUB_TOKEN instead of PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - run: npm test
     - name: Login to GitHub Container Registry
       run: |
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build Docker Image
       run: |
         docker pull ghcr.io/${{ github.repository }}:latest || :


### PR DESCRIPTION
Use GITHUB_TOKEN instead of PAT for login to GitHub Registry